### PR TITLE
Add PG product creation route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "node-fetch": "^3.3.2",
+        "pg": "^8.11.3",
         "postgresql": "^0.0.1",
         "prisma": "^6.12.0"
       },
@@ -1808,6 +1809,95 @@
         "node": ">=16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1819,6 +1909,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/postgresql": {
@@ -2118,6 +2247,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2308,6 +2446,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "jsonwebtoken": "^9.0.2",
     "node-fetch": "^3.3.2",
     "postgresql": "^0.0.1",
-    "prisma": "^6.12.0"
+    "prisma": "^6.12.0",
+    "pg": "^8.11.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",

--- a/src/controllers/productPgController.ts
+++ b/src/controllers/productPgController.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from 'express';
+import { ProductPgService, NewProduct } from '../services/pg/productPgService';
+import { AuthenticatedRequest } from '../middleware/authMiddleware';
+
+export const createProduct = async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const supplierId = req.user!.id;
+    const data = req.body as NewProduct;
+    const product = await ProductPgService.createProduct(supplierId, data);
+    res.status(201).json({ success: true, product });
+  } catch (error: any) {
+    console.error('Error creating product:', error);
+    res.status(500).json({ success: false, message: 'Error creating product' });
+  }
+};
+
+export const getProductsByCategory = async (req: Request, res: Response) => {
+  try {
+    const categoryId = parseInt(req.params.id);
+    const products = await ProductPgService.getProductsByCategory(categoryId);
+    res.json({ success: true, products });
+  } catch (error: any) {
+    console.error('Error getting products by category:', error);
+    res.status(500).json({ success: false, message: 'Error fetching products' });
+  }
+};

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,0 +1,15 @@
+import { Pool } from 'pg';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT || '5432'),
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+});
+
+export default pool;

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -153,3 +153,18 @@ export const requireSupplier = async (req: AuthenticatedRequest, res: Response, 
     next();
   });
 };
+
+export const checkRole = (role: string) => {
+  return async (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    await requireAuth(req, res, () => {
+      if (!req.user) {
+        return res.status(401).json({ success: false, message: 'Información de usuario no disponible' });
+      }
+      const userType = (req.user.userType || '').toLowerCase();
+      if (userType !== role.toLowerCase()) {
+        return res.status(403).json({ success: false, message: 'Acceso restringido para rol ' + role });
+      }
+      next();
+    });
+  };
+};

--- a/src/routes/categoryRoutes.ts
+++ b/src/routes/categoryRoutes.ts
@@ -1,12 +1,13 @@
 import { Router } from 'express';
-import { 
-  getCategories, 
-  getCategoryById, 
+import {
+  getCategories,
+  getCategoryById,
   getCategoryTree,
-  createCategory, 
-  updateCategory, 
-  deleteCategory 
+  createCategory,
+  updateCategory,
+  deleteCategory
 } from '../controllers/categoryPrismaController';
+import { getProductsByCategory } from '../controllers/productPgController';
 
 const router = Router();
 
@@ -29,5 +30,8 @@ router.put('/categories/:id', updateCategory);
 
 // DELETE /api/categories/:id - Eliminar categoría
 router.delete('/categories/:id', deleteCategory);
+
+// GET /api/categories/:id/products - Listar productos de categoría
+router.get('/categories/:id/products', getProductsByCategory);
 
 export default router;

--- a/src/routes/productRoutes.ts
+++ b/src/routes/productRoutes.ts
@@ -1,14 +1,15 @@
 import { Router } from 'express';
-import { 
-  getProducts, 
-  getProductById, 
+import {
+  getProducts,
+  getProductById,
   getFeaturedProducts,
   getNewProducts,
   searchProducts,
-  createProduct, 
-  updateProduct, 
-  deleteProduct 
+  updateProduct,
+  deleteProduct
 } from '../controllers/productPrismaController';
+import { createProduct } from '../controllers/productPgController';
+import { checkRole } from '../middleware/authMiddleware';
 
 const router = Router();
 
@@ -30,7 +31,7 @@ router.get('/search/:query', searchProducts);
 router.get('/:id', getProductById);
 
 // POST /api/products - Crear nuevo producto
-router.post('/', createProduct);
+router.post('/', checkRole('supplier'), createProduct);
 
 // PUT /api/products/:id - Actualizar producto
 router.put('/:id', updateProduct);

--- a/src/services/pg/productPgService.ts
+++ b/src/services/pg/productPgService.ts
@@ -1,0 +1,72 @@
+import pool from '../../db';
+
+export interface NewProduct {
+  title: string;
+  description?: string;
+  category_id: number;
+  price: number;
+  moq: number;
+  unit: string;
+  incoterm: string;
+  origin_country: string;
+  images?: string[];
+  specifications?: any;
+  container_type: string;
+  units_per_container: number;
+  unit_price: number;
+  price_per_container: number;
+  gross_weight: number;
+  net_weight: number;
+  volume: number;
+  packaging_type?: string;
+  production_time: number;
+  stock_containers: number;
+  is_negotiable: boolean;
+}
+
+export class ProductPgService {
+  static async createProduct(supplierId: number, data: NewProduct) {
+    const query = `INSERT INTO products (
+      title, description, category_id, supplier_id, price, moq, unit, incoterm,
+      origin_country, images, specifications, container_type, units_per_container,
+      unit_price, price_per_container, gross_weight, net_weight, volume,
+      packaging_type, production_time, stock_containers, is_negotiable
+    ) VALUES (
+      $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+    ) RETURNING *`;
+
+    const values = [
+      data.title,
+      data.description || null,
+      data.category_id,
+      supplierId,
+      data.price,
+      data.moq,
+      data.unit,
+      data.incoterm,
+      data.origin_country,
+      data.images || [],
+      data.specifications || null,
+      data.container_type,
+      data.units_per_container,
+      data.unit_price,
+      data.price_per_container,
+      data.gross_weight,
+      data.net_weight,
+      data.volume,
+      data.packaging_type || null,
+      data.production_time,
+      data.stock_containers,
+      data.is_negotiable,
+    ];
+
+    const { rows } = await pool.query(query, values);
+    return rows[0];
+  }
+
+  static async getProductsByCategory(categoryId: number) {
+    const query = 'SELECT * FROM products WHERE category_id = $1 AND is_active = true';
+    const { rows } = await pool.query(query, [categoryId]);
+    return rows;
+  }
+}


### PR DESCRIPTION
## Summary
- add PG database connection
- implement service for inserting products with pg
- create controller for PG products
- add role-based middleware checkRole
- protect POST /api/products for suppliers
- expose GET /api/categories/:id/products for buyers
- include pg dependency

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6887e334b5f483298698e5df90c00d87